### PR TITLE
Fix early connection initialization for DB provider

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## Master
 
+- Fix `database_connection_provider` config option: avoid calling connection on app initialization
+
 ## 0.7.5
 
 - Make `Hermes::Logger::ParamsFilter` correctly handle regexps

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Rails.application.config.to_prepare do
     config.adapter = Rails.application.config.async_messaging_adapter
     config.application_prefix = "my_app"
     config.background_processor = HermesHandlerJob
-    config.database_connection_provider = ActiveRecord::Base.connection
+    config.database_connection_provider = ActiveRecord::Base
     config.enqueue_method = :perform_async
     config.event_handler = event_handler
     config.clock = Time.zone
@@ -88,7 +88,7 @@ end
 
 If you know what you are doing, you don't necessarily have to process things in the background. As long as the class implements the expected interface, you can do anything you want.
 
-5. `database_connection_provider` - an object responding to `reconnect!`. It is used during synchronous flow to ensure a valid connection. Optional.
+5. `database_connection_provider` - an object responding to `connection`. It is used during synchronous flow to ensure a valid connection. Optional.
 6. `event_handler` - an instance of event handler/storage, just use what is shown in the example. Notice that you can also pass extra consumer config lambda that will be evaluated within the context of Hutch consumer.
 7. `clock` - a clock object that is time-zone aware, implementing `now` method.
 8. `configure_hutch` - a way to configure Hutch:

--- a/gemfiles/rails.6.1.gemfile
+++ b/gemfiles/rails.6.1.gemfile
@@ -4,6 +4,6 @@ source "https://rubygems.org"
 
 gem "activesupport", "~> 6.1.0"
 gem "activerecord", "~> 6.1.0"
-gem "ddtrace", "> 1.0"
+gem "ddtrace", git: "https://github.com/DataDog/dd-trace-rb.git", branch: "master"
 
 gemspec path: "../"

--- a/gemfiles/rails.7.0.gemfile
+++ b/gemfiles/rails.7.0.gemfile
@@ -4,6 +4,6 @@ source "https://rubygems.org"
 
 gem "activesupport", "~> 7.0.0"
 gem "activerecord", "~> 7.0.0"
-gem "ddtrace", "> 1.0"
+gem "ddtrace", git: "https://github.com/DataDog/dd-trace-rb.git", branch: "master"
 
 gemspec path: "../"

--- a/lib/hermes/consumer_builder.rb
+++ b/lib/hermes/consumer_builder.rb
@@ -61,7 +61,7 @@ module Hermes
         end
 
         def ensure_database_connection!
-          config.database_connection_provider.reconnect! if config.database_connection_provider
+          config.database_connection_provider.connection.reconnect! if config.database_connection_provider
         end
       end
 


### PR DESCRIPTION
If we explicitly call `config.database_connection_provider = ActiveRecord::Base.connection` in a Rails initializer - it will initialize the connection right away and it will cause `ActiveRecord::NoDatabaseError` during, say, db creation rake task.