### PR TITLE
Improve handling database connections when the server kills the connection

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Master
+- Improve handling database connections when the server kills the connection
 
 ## 0.9.0
 - Handle database reconnection for distributed traces as it might cause some issues with RPCs/synchronous flows

--- a/spec/hermes/consumer_builder_spec.rb
+++ b/spec/hermes/consumer_builder_spec.rb
@@ -271,8 +271,8 @@ RSpec.describe Hermes::ConsumerBuilder, :freeze_time do
                 it "releases DB connections" do
                   process rescue ActiveRecord::StatementInvalid
 
-                  expect(configuration.database_connection_provider.connection_pool).to have_received(:disconnect!)
-                  expect(Hermes::DistributedTrace.connection_pool).to have_received(:disconnect!)
+                  expect(configuration.database_connection_provider.connection_pool).to have_received(:disconnect!).at_least(1)
+                  expect(Hermes::DistributedTrace.connection_pool).to have_received(:disconnect!).at_least(1)
                 end
               end
 


### PR DESCRIPTION
Inspired by this: https://stackoverflow.com/questions/36582380/rails-postgres-reconnection-on-failover-for-rds

But monkeypatching it on the app level is a bit too hardcore, so let's start with the smaller scope